### PR TITLE
feat: inline review comments + remove unused id-token permission

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,7 +18,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -98,7 +97,29 @@ jobs:
 
             5. Fill in the template from `/tmp/governance/review-template.md` per `/tmp/governance/review-instructions.md`. Write to `/tmp/review.md`.
 
-            6. Post as a sticky PR comment:
+            6. Post inline review comments on specific changed lines:
+               - For each finding, note the exact file path and line number in the HEAD commit
+               - ONLY include comments for lines that appear in the diff (added or modified lines). Lines outside the diff will cause the API call to fail.
+               - Write the review payload to `/tmp/review-payload.json`:
+                 ```json
+                 {
+                   "commit_id": "${{ github.event.pull_request.head.sha }}",
+                   "event": "COMMENT",
+                   "body": "Inline comments posted. See the summary comment for the full review.",
+                   "comments": [
+                     {
+                       "path": "src/edictum_server/routes/example.py",
+                       "line": 42,
+                       "body": "🔴 **Critical:** Description of the issue.\n\n**Attack path:** An attacker could...\n\n**Fix:**\n```python\ncode fix here\n```"
+                     }
+                   ]
+                 }
+                 ```
+               - Post it: `gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --input /tmp/review-payload.json`
+               - If there are ZERO findings, skip this step entirely — do not create an empty review.
+               - If the API call fails (e.g., a line wasn't in the diff), fall back to the summary comment only.
+
+            7. Post the sticky summary comment (authoritative record of all findings):
                - Check for existing: `gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --jq '.[] | select(.body | contains("<!-- edictum-console-review -->")) | .id'`
                - If found, update: `gh api "repos/${{ github.repository }}/issues/comments/COMMENT_ID" -X PATCH -f body=@/tmp/review.md`
                - If not found, create: `gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review.md`


### PR DESCRIPTION
## Summary
- Review workflow now posts inline comments on specific changed lines via GitHub Pull Request Review API, in addition to the sticky summary comment
- Removes unused `id-token: write` permission (least privilege)

## Test plan
- [ ] Open a test PR and verify inline comments appear on changed lines
- [ ] Verify sticky summary comment still posts
- [ ] Verify fallback works if a line isn't in the diff