### PR TITLE
docs: add EDICTUM_TRUSTED_PROXIES to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,5 +54,10 @@ EDICTUM_AUTH_PROVIDER=local
 # CORS allowed origins (comma-separated)
 # EDICTUM_CORS_ORIGINS=http://localhost:8000,http://localhost:3000
 
+# Trusted proxy addresses for X-Forwarded-For/Proto (comma-separated)
+# Required when running behind a reverse proxy with HTTPS base URL.
+# Use '*' for Railway/Render, or specific IPs/CIDRs for tighter control.
+# EDICTUM_TRUSTED_PROXIES=*
+
 # Runtime environment (development | staging | production)
 # EDICTUM_ENV_NAME=development


### PR DESCRIPTION
## Summary

- Documents `EDICTUM_TRUSTED_PROXIES` in `.env.example` — was referenced in startup warnings and `config.py` but missing from the env template

## Test plan

- [x] Verify `.env.example` includes the new var with usage guidance