### PR TITLE
fix: mount static assets before SPA catch-all

### DIFF
--- a/src/edictum_server/main.py
+++ b/src/edictum_server/main.py
@@ -487,6 +487,16 @@ async def not_found_handler(
 # --- SPA serving (dashboard) ---------------------------------------------------
 _STATIC_DIR = Path(os.environ.get("EDICTUM_STATIC_DIR", "/app/static/dashboard"))
 
+# Mount static assets BEFORE the SPA catch-all so /dashboard/assets/* serves
+# real files instead of falling through to index.html.
+_ASSETS_DIR = _STATIC_DIR / "assets"
+if _ASSETS_DIR.is_dir():
+    app.mount(
+        "/dashboard/assets",
+        StaticFiles(directory=str(_ASSETS_DIR)),
+        name="dashboard-assets",
+    )
+
 
 @app.get("/dashboard/{full_path:path}", response_model=None)
 async def serve_spa(request: Request, full_path: str) -> FileResponse | HTMLResponse:  # noqa: ARG001
@@ -498,13 +508,4 @@ async def serve_spa(request: Request, full_path: str) -> FileResponse | HTMLResp
         "<h1>Dashboard not built</h1>"
         "<p>Run <code>cd dashboard && pnpm build</code> or use the Vite dev server.</p>",
         status_code=404,
-    )
-
-
-_ASSETS_DIR = _STATIC_DIR / "assets"
-if _ASSETS_DIR.is_dir():
-    app.mount(
-        "/dashboard/assets",
-        StaticFiles(directory=str(_ASSETS_DIR)),
-        name="dashboard-assets",
     )

--- a/tests/test_spa_static_assets.py
+++ b/tests/test_spa_static_assets.py
@@ -1,0 +1,109 @@
+"""Regression test: static assets under /dashboard/assets/ must be served with
+correct MIME types, NOT as text/html from the SPA catch-all.
+
+Root cause (2026-03-12): the @app.get("/dashboard/{full_path:path}") catch-all
+was registered before app.mount("/dashboard/assets", StaticFiles(...)), so every
+CSS/JS request got index.html with text/html — blank white page in production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.fixture()
+def _static_dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a fake dashboard build in a temp dir and point the app at it."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+
+    (tmp_path / "index.html").write_text(
+        "<html><head></head><body><div id='root'></div></body></html>"
+    )
+    (assets / "index-abc123.css").write_text("body { color: red; }")
+    (assets / "index-abc123.js").write_text("console.log('app');")
+    (assets / "vendor-def456.js").write_text("console.log('vendor');")
+
+    # Patch the module-level _STATIC_DIR before the app re-evaluates.
+    # We also need to re-mount the assets StaticFiles with the real directory.
+    import edictum_server.main as main_mod
+
+    monkeypatch.setattr(main_mod, "_STATIC_DIR", tmp_path)
+    monkeypatch.setattr(main_mod, "_ASSETS_DIR", assets)
+
+    # Re-mount the static files with the temp directory.
+    # Remove existing mount if any, then add ours.
+    app = main_mod.app
+    app.routes[:] = [r for r in app.routes if getattr(r, "name", None) != "dashboard-assets"]
+
+    from starlette.staticfiles import StaticFiles
+
+    app.mount("/dashboard/assets", StaticFiles(directory=str(assets)), name="dashboard-assets")
+
+    # Move the mount BEFORE the catch-all route (same fix as production code).
+    # Find the catch-all and the mount, ensure mount comes first.
+    mount_route = None
+    catchall_idx = None
+    for i, route in enumerate(app.routes):
+        if getattr(route, "name", None) == "dashboard-assets":
+            mount_route = route
+        if getattr(route, "name", None) == "serve_spa":
+            catchall_idx = i
+
+    if mount_route and catchall_idx is not None:
+        app.routes.remove(mount_route)
+        app.routes.insert(catchall_idx, mount_route)
+
+    return tmp_path
+
+
+@pytest.mark.usefixtures("_static_dashboard")
+async def test_css_served_with_correct_mime(no_auth_client: AsyncClient) -> None:
+    """CSS files must return text/css, not text/html."""
+    resp = await no_auth_client.get("/dashboard/assets/index-abc123.css")
+    assert resp.status_code == 200
+    content_type = resp.headers.get("content-type", "")
+    assert (
+        "text/css" in content_type
+    ), f"CSS file served as {content_type!r} — SPA catch-all is intercepting static assets"
+    assert "body { color: red; }" in resp.text
+
+
+@pytest.mark.usefixtures("_static_dashboard")
+async def test_js_served_with_correct_mime(no_auth_client: AsyncClient) -> None:
+    """JS files must return application/javascript, not text/html."""
+    resp = await no_auth_client.get("/dashboard/assets/index-abc123.js")
+    assert resp.status_code == 200
+    content_type = resp.headers.get("content-type", "")
+    assert (
+        "javascript" in content_type
+    ), f"JS file served as {content_type!r} — SPA catch-all is intercepting static assets"
+    assert "console.log('app');" in resp.text
+
+
+@pytest.mark.usefixtures("_static_dashboard")
+async def test_spa_catchall_still_works(no_auth_client: AsyncClient) -> None:
+    """Non-asset dashboard routes should still return index.html for client-side routing."""
+    resp = await no_auth_client.get("/dashboard/events")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+    assert "<div id='root'>" in resp.text
+
+
+@pytest.mark.usefixtures("_static_dashboard")
+async def test_nonexistent_asset_not_served_as_html(no_auth_client: AsyncClient) -> None:
+    """Missing assets must NOT silently return index.html (the original bug).
+
+    Starlette's StaticFiles raises 404, which the global 404 handler converts
+    to a 302 redirect.  Either way, it must NOT return 200 with text/html — that
+    would mean the SPA catch-all swallowed the request.
+    """
+    resp = await no_auth_client.get(
+        "/dashboard/assets/nonexistent.js",
+        follow_redirects=False,
+    )
+    # 404 or 302 redirect — both acceptable. 200 text/html is the bug.
+    assert resp.status_code != 200, "Missing asset returned 200 — catch-all is swallowing it"


### PR DESCRIPTION
## Summary
- **Root cause:** `@app.get("/dashboard/{full_path:path}")` catch-all was registered before `app.mount("/dashboard/assets", StaticFiles(...))`, so all CSS/JS asset requests matched the catch-all and got `index.html` with `text/html` MIME type. Browsers rejected them (strict MIME checking) → blank white page.
- **Fix:** Move the `StaticFiles` mount above the SPA catch-all route so `/dashboard/assets/*` is matched first.
- **Regression tests:** 4 new tests verify CSS returns `text/css`, JS returns `application/javascript`, SPA catch-all still works for client routes, and missing assets don't silently return `index.html`.

## Test plan
- [x] `pytest tests/test_spa_static_assets.py` — 4/4 passing
- [ ] Rebuild Docker image, deploy to arnold, verify dashboard loads
- [ ] Check browser DevTools — no MIME type errors in console