### PR TITLE
fix: set Cache-Control: no-cache on SPA index.html

### DIFF
--- a/src/edictum_server/main.py
+++ b/src/edictum_server/main.py
@@ -503,7 +503,13 @@ async def serve_spa(request: Request, full_path: str) -> FileResponse | HTMLResp
     """Serve the React SPA — return index.html for all routes (client-side routing)."""
     index = _STATIC_DIR.resolve() / "index.html"
     if index.is_file():
-        return FileResponse(index)
+        return FileResponse(
+            index,
+            # Never cache index.html at CDN layer — it references content-hashed
+            # assets that change on every build.  Without this, CDNs (Railway's
+            # Fastly edge, Cloudflare) cache stale HTML for hours.
+            headers={"Cache-Control": "no-cache"},
+        )
     return HTMLResponse(
         "<h1>Dashboard not built</h1>"
         "<p>Run <code>cd dashboard && pnpm build</code> or use the Vite dev server.</p>",

--- a/tests/test_spa_static_assets.py
+++ b/tests/test_spa_static_assets.py
@@ -107,3 +107,18 @@ async def test_nonexistent_asset_not_served_as_html(no_auth_client: AsyncClient)
     )
     # 404 or 302 redirect — both acceptable. 200 text/html is the bug.
     assert resp.status_code != 200, "Missing asset returned 200 — catch-all is swallowing it"
+
+
+@pytest.mark.usefixtures("_static_dashboard")
+async def test_spa_index_has_no_cache_header(no_auth_client: AsyncClient) -> None:
+    """index.html must set Cache-Control: no-cache so CDNs don't cache stale HTML.
+
+    Without this, Railway (Fastly) and Cloudflare cache index.html for hours.
+    When asset hashes change on redeploy, cached HTML references old assets → blank page.
+    """
+    resp = await no_auth_client.get("/dashboard/")
+    assert resp.status_code == 200
+    cache_control = resp.headers.get("cache-control", "")
+    assert (
+        "no-cache" in cache_control
+    ), f"index.html has Cache-Control: {cache_control!r} — CDNs will cache stale HTML"


### PR DESCRIPTION
## Summary
- Railway (Fastly) and Cloudflare cache responses with `max-age=14400` (4h) when no `Cache-Control` is set. After a deploy, CDNs served stale `index.html` referencing old content-hashed assets → blank page for up to 4 hours.
- Set `Cache-Control: no-cache` on the SPA catch-all so CDNs always revalidate `index.html`. Hashed assets in `/dashboard/assets/` remain cacheable (immutable filenames).
- Regression test verifies the header is present.

## Test plan
- [x] `pytest tests/test_spa_static_assets.py` — 5/5 passing
- [ ] Deploy, verify `curl -I` shows `cache-control: no-cache` on `/dashboard/`
- [ ] Redeploy again, confirm dashboard loads immediately without cache purge