### PR TITLE
refactor: move business logic from routes to services (DDD cleanup)

### DIFF
--- a/scripts/security-lint/check_tenant_isolation.py
+++ b/scripts/security-lint/check_tenant_isolation.py
@@ -34,17 +34,21 @@ SCAN_DIRS = [
 # ---------------------------------------------------------------------------
 
 ALLOWED_FILES: set[str] = {
-    "routes/health.py",       # System-wide health check, no auth
-    "routes/auth.py",         # Auth endpoints, no tenant context yet
-    "routes/setup.py",        # Bootstrap endpoint, S7 guarded
-    "routes/slack.py",        # Webhook callback, tenant resolved from Redis
-    "routes/telegram.py",     # Webhook callback, tenant resolved from Redis
-    "routes/discord.py",      # Webhook callback, tenant resolved from Redis
+    "routes/health.py",  # System-wide health check, no auth
+    "routes/auth.py",  # Auth endpoints, no tenant context yet
+    "routes/setup.py",  # Bootstrap endpoint, S7 guarded
+    "routes/slack.py",  # Webhook callback, tenant resolved from Redis
+    "routes/telegram.py",  # Webhook callback, tenant resolved from Redis
+    "routes/discord.py",  # Webhook callback, tenant resolved from Redis
 }
 
 ALLOWED_FUNCTIONS: set[str] = {
     # System-level functions that intentionally operate across all tenants.
-    "expire_approvals",       # Background task: expires all pending approvals globally
+    "expire_approvals",  # Background task: expires all pending approvals globally
+    "find_user_by_email",  # Login: user lookup before tenant is known
+    "get_user_count",  # Health/bootstrap check: system-wide, no auth
+    "find_enabled_channels_by_type",  # Webhook: tenant resolved via signature verification
+    "find_channel_by_id_and_type",  # Webhook: tenant resolved via signature verification
 }
 
 # The token we require somewhere in the same statement to prove tenant scoping.
@@ -70,10 +74,7 @@ _SUBQUERY_SELECT_RE = re.compile(r"select\s*\(\s*\w+\.c\.")
 
 def _is_allowed_file(rel_path: str) -> bool:
     """Check if a file is in the allowlist."""
-    for allowed in ALLOWED_FILES:
-        if rel_path.endswith(allowed):
-            return True
-    return False
+    return any(rel_path.endswith(allowed) for allowed in ALLOWED_FILES)
 
 
 def _find_enclosing_function(lines: list[str], line_idx: int) -> str | None:
@@ -84,9 +85,9 @@ def _find_enclosing_function(lines: list[str], line_idx: int) -> str | None:
             parts = stripped.split("(", 1)
             name_part = parts[0]
             if name_part.startswith("async def "):
-                return name_part[len("async def "):]
+                return name_part[len("async def ") :]
             if name_part.startswith("def "):
-                return name_part[len("def "):]
+                return name_part[len("def ") :]
     return None
 
 
@@ -103,11 +104,11 @@ def _count_parens(line: str) -> int:
     j = 0
     while j < len(line):
         if not in_single_quote and not in_double_quote:
-            if line[j:j + 3] == '"""':
+            if line[j : j + 3] == '"""':
                 in_triple_double = not in_triple_double
                 j += 3
                 continue
-            if line[j:j + 3] == "'''":
+            if line[j : j + 3] == "'''":
                 in_triple_single = not in_triple_single
                 j += 3
                 continue
@@ -364,8 +365,7 @@ def scan_file(filepath: Path, verbose: bool = False) -> list[str]:
             if func_name and func_name in ALLOWED_FUNCTIONS:
                 if verbose:
                     print(
-                        f"  SKIP (allowlisted function): "
-                        f"{rel_path}:{i + 1} in {func_name}()"
+                        f"  SKIP (allowlisted function): " f"{rel_path}:{i + 1} in {func_name}()"
                     )
                 i += 1
                 continue
@@ -380,20 +380,14 @@ def scan_file(filepath: Path, verbose: bool = False) -> list[str]:
                 # patterns that the single-line check may have missed).
                 if ".correlate(" in statement or ".scalar_subquery()" in statement:
                     if verbose:
-                        print(
-                            f"  SKIP (correlated subquery): "
-                            f"{rel_path}:{i + 1}"
-                        )
+                        print(f"  SKIP (correlated subquery): " f"{rel_path}:{i + 1}")
                     i = end_idx + 1
                     continue
 
                 # Check for subquery column access in the full statement
                 if _SUBQUERY_SELECT_RE.search(statement):
                     if verbose:
-                        print(
-                            f"  SKIP (subquery column select): "
-                            f"{rel_path}:{i + 1}"
-                        )
+                        print(f"  SKIP (subquery column select): " f"{rel_path}:{i + 1}")
                     i = end_idx + 1
                     continue
 
@@ -405,18 +399,12 @@ def scan_file(filepath: Path, verbose: bool = False) -> list[str]:
                     func_body = _get_function_body(lines, i)
                     if TENANT_TOKEN in func_body:
                         if verbose:
-                            print(
-                                f"  SKIP (tenant_id via *filters): "
-                                f"{rel_path}:{i + 1}"
-                            )
+                            print(f"  SKIP (tenant_id via *filters): " f"{rel_path}:{i + 1}")
                         i = end_idx + 1
                         continue
 
                 line_num = i + 1
-                msg = (
-                    f"FAIL: {rel_path}:{line_num} "
-                    f"-- {op_name}() without tenant_id filter"
-                )
+                msg = f"FAIL: {rel_path}:{line_num} " f"-- {op_name}() without tenant_id filter"
                 if func_name:
                     msg += f" [in {func_name}()]"
                 violations.append(msg)
@@ -442,7 +430,8 @@ def main() -> int:
         description="Check tenant isolation on SQLAlchemy queries (S3 boundary)."
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Print skipped files/functions and offending statement snippets.",
     )
@@ -476,19 +465,13 @@ def main() -> int:
         for v in all_violations:
             print(f"  {v}")
         print()
-        print(
-            f"Scanned {files_scanned} files. "
-            f"Found {len(all_violations)} violation(s)."
-        )
+        print(f"Scanned {files_scanned} files. " f"Found {len(all_violations)} violation(s).")
         print()
         print("To suppress false positives, add entries to ALLOWED_FILES or")
         print("ALLOWED_FUNCTIONS at the top of this script.")
         return 1
     else:
-        print(
-            f"OK: Scanned {files_scanned} files. "
-            f"No tenant isolation violations found."
-        )
+        print(f"OK: Scanned {files_scanned} files. " f"No tenant isolation violations found.")
         return 0
 
 

--- a/src/edictum_server/routes/ai.py
+++ b/src/edictum_server/routes/ai.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import time
-import uuid
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -25,6 +24,7 @@ from edictum_server.services.ai_service import (
     decrypt_api_key,
     delete_ai_config,
     get_ai_config,
+    log_usage,
     mask_api_key,
     upsert_ai_config,
 )
@@ -318,7 +318,7 @@ async def assist(
                 yield f"data: {json.dumps(usage_event)}\n\n"
 
                 # Persist usage log
-                await _log_usage(
+                await log_usage(
                     tenant_id=tenant_id,
                     provider_name=provider_name,
                     model=model_name,
@@ -345,36 +345,3 @@ async def assist(
             "X-Accel-Buffering": "no",
         },
     )
-
-
-async def _log_usage(
-    *,
-    tenant_id: uuid.UUID,
-    provider_name: str,
-    model: str,
-    input_tokens: int,
-    output_tokens: int,
-    total_tokens: int,
-    duration_ms: int,
-    cost: float | None,
-) -> None:
-    """Persist an AI usage log entry. Fire-and-forget — errors are logged, not raised."""
-    try:
-        from edictum_server.db.engine import async_session_factory
-        from edictum_server.db.models import AiUsageLog
-
-        async with async_session_factory()() as session:
-            log = AiUsageLog(
-                tenant_id=tenant_id,
-                provider=provider_name,
-                model=model,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                total_tokens=total_tokens,
-                duration_ms=duration_ms,
-                estimated_cost_usd=cost,
-            )
-            session.add(log)
-            await session.commit()
-    except Exception:
-        logger.exception("Failed to log AI usage for tenant %s", tenant_id)

--- a/src/edictum_server/routes/approvals.py
+++ b/src/edictum_server/routes/approvals.py
@@ -9,7 +9,6 @@ import uuid
 import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.auth.dependencies import (
@@ -44,6 +43,7 @@ def _fire(coro: object) -> None:
             logger.exception("Unhandled error in background notification task")
 
     asyncio.create_task(_run())
+
 
 router = APIRouter(prefix="/api/v1/approvals", tags=["approvals"])
 
@@ -94,7 +94,11 @@ async def create_approval(
     # Identity from auth context, not request body (CLAUDE.md rule)
     agent_id = auth.agent_id or f"key:{auth.api_key_prefix or 'unknown'}"
     approval = await approval_service.create_approval(
-        db, auth.tenant_id, body, env=env, agent_id=agent_id,
+        db,
+        auth.tenant_id,
+        body,
+        env=env,
+        agent_id=agent_id,
     )
     await db.commit()
 
@@ -157,12 +161,13 @@ async def list_approvals(
     db: AsyncSession = Depends(get_db),
 ) -> list[ApprovalResponse]:
     """List approvals, optionally filtered by status."""
-    stmt = select(Approval).where(Approval.tenant_id == auth.tenant_id)
-    if status:
-        stmt = stmt.where(Approval.status == status)
-    stmt = stmt.order_by(Approval.created_at.desc()).limit(limit).offset(offset)
-    result = await db.execute(stmt)
-    approvals = list(result.scalars().all())
+    approvals = await approval_service.list_approvals(
+        db,
+        auth.tenant_id,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
     return [_to_response(a) for a in approvals]
 
 

--- a/src/edictum_server/routes/auth.py
+++ b/src/edictum_server/routes/auth.py
@@ -9,15 +9,14 @@ import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.auth.local import LocalAuthProvider
 from edictum_server.auth.provider import DashboardAuthContext
 from edictum_server.db.engine import get_db
-from edictum_server.db.models import User
 from edictum_server.rate_limit import RateLimitExceeded, check_rate_limit
 from edictum_server.redis.client import get_redis
+from edictum_server.services.auth_service import find_user_by_email
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +79,7 @@ async def login(
             headers={"Retry-After": str(exc.retry_after)},
         )
 
-    result = await db.execute(select(User).where(User.email == body.email))
-    user = result.scalar_one_or_none()
+    user = await find_user_by_email(db, body.email)
 
     # Timing-safe: always run bcrypt verification to prevent account
     # enumeration via response-time differences (issue #15).

--- a/src/edictum_server/routes/discord.py
+++ b/src/edictum_server/routes/discord.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.config import get_settings
@@ -21,7 +20,10 @@ from edictum_server.db.models import NotificationChannel as ChannelModel
 from edictum_server.notifications.base import NotificationManager
 from edictum_server.push.manager import PushManager
 from edictum_server.services import approval_service
-from edictum_server.services.notification_service import get_channel_config
+from edictum_server.services.notification_service import (
+    find_enabled_channels_by_type,
+    get_channel_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,13 +66,7 @@ async def discord_interaction(
     except ValueError:
         encryption_secret = None
 
-    result = await db.execute(
-        select(ChannelModel).where(
-            ChannelModel.channel_type == "discord",
-            ChannelModel.enabled == True,  # noqa: E712
-        )
-    )
-    db_channels = result.scalars().all()
+    db_channels = await find_enabled_channels_by_type(db, "discord")
 
     matched_channel: ChannelModel | None = None
     for ch in db_channels:

--- a/src/edictum_server/routes/health.py
+++ b/src/edictum_server/routes/health.py
@@ -7,14 +7,14 @@ import time
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server import __version__
 from edictum_server.auth.dependencies import AuthContext, require_dashboard_auth
 from edictum_server.config import Settings, get_settings
 from edictum_server.db.engine import get_db
-from edictum_server.db.models import User
+from edictum_server.services.health_service import get_user_count
 
 router = APIRouter(prefix="/api/v1", tags=["health"])
 
@@ -49,13 +49,14 @@ async def health(
     Only exposes operational status and bootstrap state (needed by
     the setup wizard before any user exists).
     """
-    result = await db.execute(select(func.count()).select_from(User))
-    user_count = result.scalar() or 0
+    user_count = await get_user_count(db)
 
-    return JSONResponse(content={
-        "status": "ok",
-        "bootstrap_complete": user_count > 0,
-    })
+    return JSONResponse(
+        content={
+            "status": "ok",
+            "bootstrap_complete": user_count > 0,
+        }
+    )
 
 
 @router.get("/health/details")
@@ -70,8 +71,7 @@ async def health_details(
     Returns version, infrastructure status, worker health, and connected
     agent count. Requires dashboard session cookie. Returns 503 when degraded.
     """
-    result = await db.execute(select(func.count()).select_from(User))
-    user_count = result.scalar() or 0
+    user_count = await get_user_count(db)
 
     # DB latency
     db_start = time.monotonic()

--- a/src/edictum_server/routes/keys.py
+++ b/src/edictum_server/routes/keys.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.auth.api_keys import generate_api_key
@@ -15,6 +13,7 @@ from edictum_server.db.engine import get_db
 from edictum_server.db.models import ApiKey
 from edictum_server.push.manager import PushManager, get_push_manager
 from edictum_server.schemas.keys import ApiKeyInfo, CreateKeyRequest, CreateKeyResponse
+from edictum_server.services import key_service
 
 router = APIRouter(prefix="/api/v1/keys", tags=["keys"])
 
@@ -74,13 +73,7 @@ async def list_keys(
     db: AsyncSession = Depends(get_db),
 ) -> list[ApiKeyInfo]:
     """List all non-revoked API keys for the authenticated tenant."""
-    result = await db.execute(
-        select(ApiKey).where(
-            ApiKey.tenant_id == auth.tenant_id,
-            ApiKey.revoked_at.is_(None),
-        )
-    )
-    rows = result.scalars().all()
+    rows = await key_service.list_api_keys(db, auth.tenant_id)
 
     return [
         ApiKeyInfo(
@@ -105,26 +98,12 @@ async def revoke_key(
 
     Only the owning tenant (via dashboard auth) can revoke their keys.
     """
-    result = await db.execute(
-        select(ApiKey).where(
-            ApiKey.id == key_id,
-            ApiKey.tenant_id == auth.tenant_id,
-            ApiKey.revoked_at.is_(None),
-        )
-    )
-    api_key = result.scalar_one_or_none()
-
-    if api_key is None:
+    revoked = await key_service.revoke_api_key(db, auth.tenant_id, key_id)
+    if not revoked:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="API key not found or already revoked.",
         )
-
-    await db.execute(
-        update(ApiKey)
-        .where(ApiKey.id == key_id, ApiKey.tenant_id == auth.tenant_id)
-        .values(revoked_at=datetime.now(UTC))
-    )
     await db.commit()
 
     push.push_to_dashboard(

--- a/src/edictum_server/routes/slack.py
+++ b/src/edictum_server/routes/slack.py
@@ -13,16 +13,17 @@ from urllib.parse import parse_qs
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.config import get_settings
 from edictum_server.db.engine import get_db
-from edictum_server.db.models import NotificationChannel as ChannelModel
 from edictum_server.notifications.base import NotificationManager
 from edictum_server.push.manager import PushManager
 from edictum_server.services import approval_service
-from edictum_server.services.notification_service import get_channel_config
+from edictum_server.services.notification_service import (
+    find_enabled_channels_by_type,
+    get_channel_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,13 +73,7 @@ async def slack_interaction(
     except ValueError:
         encryption_secret = None
 
-    result = await db.execute(
-        select(ChannelModel).where(
-            ChannelModel.channel_type == "slack_app",
-            ChannelModel.enabled == True,  # noqa: E712
-        )
-    )
-    db_channels = list(result.scalars())
+    db_channels = await find_enabled_channels_by_type(db, "slack_app")
 
     matched_channel = None
     for ch in db_channels:

--- a/src/edictum_server/routes/telegram.py
+++ b/src/edictum_server/routes/telegram.py
@@ -11,17 +11,18 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import Response
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.config import get_settings
 from edictum_server.db.engine import get_db
-from edictum_server.db.models import NotificationChannel as ChannelModel
 from edictum_server.notifications.base import NotificationManager
 from edictum_server.notifications.telegram import TelegramChannel
 from edictum_server.push.manager import PushManager
 from edictum_server.services import approval_service
-from edictum_server.services.notification_service import get_channel_config
+from edictum_server.services.notification_service import (
+    find_channel_by_id_and_type,
+    get_channel_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -163,14 +164,7 @@ async def db_channel_webhook(
     except ValueError:
         return Response(status_code=404)
 
-    result = await db.execute(
-        select(ChannelModel).where(
-            ChannelModel.id == ch_uuid,
-            ChannelModel.channel_type == "telegram",
-            ChannelModel.enabled == True,  # noqa: E712
-        )
-    )
-    db_channel = result.scalar_one_or_none()
+    db_channel = await find_channel_by_id_and_type(db, ch_uuid, "telegram")
     if db_channel is None:
         return Response(status_code=404)
 

--- a/src/edictum_server/services/ai_service.py
+++ b/src/edictum_server/services/ai_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from nacl.secret import SecretBox
@@ -12,15 +13,15 @@ from edictum_server.db.models import TenantAiConfig
 from edictum_server.security.validators import ValidationError as SecurityError
 from edictum_server.security.validators import validate_url
 
+logger = logging.getLogger(__name__)
+
 
 async def get_ai_config(
     db: AsyncSession,
     tenant_id: uuid.UUID,
 ) -> TenantAiConfig | None:
     """Fetch the AI config for a tenant, or None if not configured."""
-    result = await db.execute(
-        select(TenantAiConfig).where(TenantAiConfig.tenant_id == tenant_id)
-    )
+    result = await db.execute(select(TenantAiConfig).where(TenantAiConfig.tenant_id == tenant_id))
     return result.scalar_one_or_none()
 
 
@@ -96,3 +97,36 @@ def mask_api_key(raw: str) -> str:
     if len(raw) <= 12:
         return "***"
     return f"{raw[:8]}...{raw[-4:]}"
+
+
+async def log_usage(
+    *,
+    tenant_id: uuid.UUID,
+    provider_name: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    total_tokens: int,
+    duration_ms: int,
+    cost: float | None,
+) -> None:
+    """Persist an AI usage log entry. Fire-and-forget — errors are logged, not raised."""
+    try:
+        from edictum_server.db.engine import async_session_factory
+        from edictum_server.db.models import AiUsageLog
+
+        async with async_session_factory()() as session:
+            log = AiUsageLog(
+                tenant_id=tenant_id,
+                provider=provider_name,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+                duration_ms=duration_ms,
+                estimated_cost_usd=cost,
+            )
+            session.add(log)
+            await session.commit()
+    except Exception:
+        logger.exception("Failed to log AI usage for tenant %s", tenant_id)

--- a/src/edictum_server/services/approval_service.py
+++ b/src/edictum_server/services/approval_service.py
@@ -119,6 +119,23 @@ async def list_pending_approvals(
     return list(result.scalars().all())
 
 
+async def list_approvals(
+    db: AsyncSession,
+    tenant_id: uuid.UUID,
+    *,
+    status: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[Approval]:
+    """List approvals for a tenant, optionally filtered by status."""
+    stmt = select(Approval).where(Approval.tenant_id == tenant_id)
+    if status:
+        stmt = stmt.where(Approval.status == status)
+    stmt = stmt.order_by(Approval.created_at.desc()).limit(limit).offset(offset)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
 async def submit_decision(
     db: AsyncSession,
     tenant_id: uuid.UUID,

--- a/src/edictum_server/services/auth_service.py
+++ b/src/edictum_server/services/auth_service.py
@@ -1,0 +1,17 @@
+"""Authentication service — user lookup operations."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from edictum_server.db.models import User
+
+
+async def find_user_by_email(
+    db: AsyncSession,
+    email: str,
+) -> User | None:
+    """Find a user by email. Returns None if not found."""
+    result = await db.execute(select(User).where(User.email == email))
+    return result.scalar_one_or_none()

--- a/src/edictum_server/services/health_service.py
+++ b/src/edictum_server/services/health_service.py
@@ -1,0 +1,14 @@
+"""Health service — bootstrap status and infrastructure checks."""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from edictum_server.db.models import User
+
+
+async def get_user_count(db: AsyncSession) -> int:
+    """Get the total number of users. Used for bootstrap status check."""
+    result = await db.execute(select(func.count()).select_from(User))
+    return result.scalar() or 0

--- a/src/edictum_server/services/key_service.py
+++ b/src/edictum_server/services/key_service.py
@@ -1,0 +1,58 @@
+"""API key management service — list, revoke operations."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from edictum_server.db.models import ApiKey
+
+
+async def list_api_keys(
+    db: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> list[ApiKey]:
+    """List all non-revoked API keys for a tenant."""
+    result = await db.execute(
+        select(ApiKey).where(
+            ApiKey.tenant_id == tenant_id,
+            ApiKey.revoked_at.is_(None),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def get_api_key(
+    db: AsyncSession,
+    tenant_id: uuid.UUID,
+    key_id: uuid.UUID,
+) -> ApiKey | None:
+    """Get a single non-revoked API key by ID, scoped to tenant."""
+    result = await db.execute(
+        select(ApiKey).where(
+            ApiKey.id == key_id,
+            ApiKey.tenant_id == tenant_id,
+            ApiKey.revoked_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def revoke_api_key(
+    db: AsyncSession,
+    tenant_id: uuid.UUID,
+    key_id: uuid.UUID,
+) -> bool:
+    """Revoke an API key by setting revoked_at. Returns False if not found."""
+    key = await get_api_key(db, tenant_id, key_id)
+    if key is None:
+        return False
+    await db.execute(
+        update(ApiKey)
+        .where(ApiKey.id == key_id, ApiKey.tenant_id == tenant_id)
+        .values(revoked_at=datetime.now(UTC))
+    )
+    return True

--- a/src/edictum_server/services/notification_service.py
+++ b/src/edictum_server/services/notification_service.py
@@ -111,6 +111,47 @@ async def _validate_urls(channel_type: str, config: dict[str, Any]) -> None:
                 raise ValueError(f"Invalid {field}: {exc}") from exc
 
 
+async def find_enabled_channels_by_type(
+    db: AsyncSession,
+    channel_type: str,
+) -> list[NotificationChannel]:
+    """Find all enabled channels of a given type.
+
+    Used by webhook handlers (Slack, Discord, Telegram) where authentication
+    is via signature verification rather than session/API key. The query does
+    NOT filter by tenant_id because the webhook doesn't know the tenant yet —
+    tenant scoping comes from matching the channel's own tenant_id after
+    signature verification succeeds.
+    """
+    result = await db.execute(
+        select(NotificationChannel).where(
+            NotificationChannel.channel_type == channel_type,
+            NotificationChannel.enabled == True,  # noqa: E712
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def find_channel_by_id_and_type(
+    db: AsyncSession,
+    channel_id: uuid.UUID,
+    channel_type: str,
+) -> NotificationChannel | None:
+    """Find a single enabled channel by ID and type.
+
+    Used by Telegram webhook where the channel_id is in the URL path.
+    Does NOT filter by tenant_id — see find_enabled_channels_by_type docstring.
+    """
+    result = await db.execute(
+        select(NotificationChannel).where(
+            NotificationChannel.id == channel_id,
+            NotificationChannel.channel_type == channel_type,
+            NotificationChannel.enabled == True,  # noqa: E712
+        )
+    )
+    return result.scalar_one_or_none()
+
+
 async def list_channels(
     db: AsyncSession,
     tenant_id: uuid.UUID,


### PR DESCRIPTION
## Summary

- Move direct DB queries and business logic out of route handlers into service functions per DDD layer rules (CLAUDE.md: "Routes are thin HTTP handlers")
- Create 3 new service files: `key_service.py`, `auth_service.py`, `health_service.py`
- Extend 3 existing services: `ai_service.log_usage()`, `approval_service.list_approvals()`, `notification_service.find_enabled_channels_by_type/find_channel_by_id_and_type()`
- Thin down 8 route files: `ai`, `approvals`, `keys`, `slack`, `discord`, `telegram`, `auth`, `health`
- Update security lint allowlist for new service functions (false positives: pre-auth and webhook queries that intentionally skip tenant_id)

## What moved where

| Route | Logic moved | New service function |
|-------|------------|---------------------|
| `routes/ai.py` | `_log_usage()` DB insert | `ai_service.log_usage()` |
| `routes/approvals.py` | `select(Approval)` with filters | `approval_service.list_approvals()` |
| `routes/keys.py` | `select(ApiKey)` + `update(ApiKey)` | `key_service.list_api_keys()` / `revoke_api_key()` |
| `routes/slack.py` | `select(ChannelModel)` | `notification_service.find_enabled_channels_by_type()` |
| `routes/discord.py` | `select(ChannelModel)` | `notification_service.find_enabled_channels_by_type()` |
| `routes/telegram.py` | `select(ChannelModel)` | `notification_service.find_channel_by_id_and_type()` |
| `routes/auth.py` | `select(User)` | `auth_service.find_user_by_email()` |
| `routes/health.py` | `select(func.count())` | `health_service.get_user_count()` |

## Rules followed

- No API behavior, response shapes, or status codes changed
- Services have zero FastAPI imports — raise ValueError/domain exceptions
- Routes translate exceptions to HTTP status codes
- Webhook channel lookups document why tenant_id is intentionally absent (signature verification provides auth)

## Test plan

- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run ruff format --check` — passed
- [x] `uv run mypy src/` — 0 issues in 113 files
- [x] `uv run pytest tests/ -v` — 575 passed
- [x] `check_tenant_isolation.py` — passed (allowlist updated)
- [x] `check_input_bounds.py` — passed
- [x] `check_timing_safe.py` — passed