### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "edictum-console"
-version = "0.1.2"
+version = "0.1.3"
 description = "Self-hostable agent operations console — runtime governance for AI agents"
 requires-python = ">=3.12"
 license = "FSL-1.1-ALv2"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version to `0.1.3`

Merge, then the GitHub release tag triggers Docker publish to GHCR.