### PR TITLE
feat(events): server-side histogram for full event distribution

### DIFF
--- a/dashboard/src/lib/api/events.ts
+++ b/dashboard/src/lib/api/events.ts
@@ -31,3 +31,28 @@ export function listEvents(filters: EventFilters = {}) {
   const qs = params.toString()
   return request<EventResponse[]>(`/events${qs ? `?${qs}` : ""}`)
 }
+
+export interface HistogramBucketResponse {
+  bucket_start: string
+  allowed: number
+  denied: number
+  pending: number
+  observed: number
+}
+
+export interface HistogramFilters {
+  since: string
+  until: string
+  bucket_seconds: number
+  agent_id?: string
+  tool_name?: string
+  verdict?: string
+}
+
+export function getEventHistogram(filters: HistogramFilters) {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined) params.set(key, String(value))
+  }
+  return request<HistogramBucketResponse[]>(`/events/histogram?${params}`)
+}

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -1,6 +1,6 @@
 export { ApiError, requestVoid } from "./client"
 export { getHealth, getHealthDetails, login, logout, getMe, setup, listKeys, createKey, deleteKey } from "./auth"
-export { listEvents } from "./events"
+export { listEvents, getEventHistogram } from "./events"
 export { listApprovals, getApproval, submitDecision } from "./approvals"
 export { listBundles, listBundleVersions, uploadBundle, deployBundle, getBundleYaml, getCurrentBundle, evaluateBundle, listDeployments } from "./bundles"
 export { getAgentStatus, getAgentCoverage, getFleetCoverage, getAgentHistory } from "./agents"
@@ -10,7 +10,7 @@ export { listContracts, getContract, getContractVersion, createContract, updateC
 export { listCompositions, getComposition, createComposition, updateComposition, deleteComposition, previewComposition, deployComposition } from "./compositions"
 
 export type { HealthResponse, HealthDetailsResponse, ServiceHealth, UserInfo, SetupResponse, ApiKeyInfo, CreateKeyResponse } from "./auth"
-export type { EventResponse, EventFilters } from "./events"
+export type { EventResponse, EventFilters, HistogramBucketResponse, HistogramFilters } from "./events"
 export type { ApprovalResponse, ApprovalFilters } from "./approvals"
 export type { BundleSummary, BundleResponse, BundleWithDeployments, DeploymentResponse, EvaluateRequest, EvaluateResponse, ContractEvaluation } from "./bundles"
 export type {

--- a/dashboard/src/lib/histogram.ts
+++ b/dashboard/src/lib/histogram.ts
@@ -92,7 +92,7 @@ function formatBucketLabelForWindow(date: Date, windowMs: number): string {
   return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true })
 }
 
-function bestBucketConfig(windowMs: number): { bucketCount: number; bucketMs: number } {
+export function bestBucketConfig(windowMs: number): { bucketCount: number; bucketMs: number } {
   const targets = [
     5 * 60 * 1000, 15 * 60 * 1000, 30 * 60 * 1000, 60 * 60 * 1000,
     2 * 60 * 60 * 1000, 6 * 60 * 60 * 1000, 12 * 60 * 60 * 1000, 24 * 60 * 60 * 1000,
@@ -182,6 +182,69 @@ export function buildHistogram(events: EventForHistogram[], tw: TimeWindow): His
     }
     buckets.push(bucket)
   }
+  return buckets
+}
+
+/** Build histogram from server-side aggregated data.
+ *  Server returns pre-classified counts per epoch-aligned bucket.
+ *  This generates the full bucket array (including empty buckets) and fills in server data.
+ */
+export function buildHistogramFromServer(
+  serverBuckets: Array<{
+    bucket_start: string
+    allowed: number
+    denied: number
+    pending: number
+    observed: number
+  }>,
+  tw: TimeWindow,
+): HistogramBucket[] {
+  let bucketMs: number
+  let windowStart: number
+  let windowEnd: number
+
+  if (tw.kind === "preset") {
+    const cfg = PRESETS[tw.key]
+    bucketMs = cfg.bucketMs
+    windowEnd = Date.now()
+    windowStart = windowEnd - cfg.windowMs
+  } else {
+    const windowMs = tw.end - tw.start
+    bucketMs = bestBucketConfig(windowMs).bucketMs
+    windowStart = tw.start
+    windowEnd = tw.end
+  }
+
+  const windowMs = windowEnd - windowStart
+  const bucketSeconds = Math.round(bucketMs / 1000)
+
+  // Build lookup: epoch-aligned bucket start (ms) → server counts
+  const serverMap = new Map<number, (typeof serverBuckets)[0]>()
+  for (const b of serverBuckets) {
+    serverMap.set(new Date(b.bucket_start).getTime(), b)
+  }
+
+  // Generate epoch-aligned buckets spanning the window
+  const alignedStartSec = Math.floor(windowStart / 1000 / bucketSeconds) * bucketSeconds
+
+  const buckets: HistogramBucket[] = []
+  for (let sec = alignedStartSec; sec * 1000 < windowEnd; sec += bucketSeconds) {
+    const startMs = sec * 1000
+    const endMs = startMs + bucketMs
+    const server = serverMap.get(startMs)
+
+    buckets.push({
+      time: formatBucketLabelForWindow(new Date(endMs), windowMs),
+      allowed: server?.allowed ?? 0,
+      denied: server?.denied ?? 0,
+      pending: server?.pending ?? 0,
+      observed: server?.observed ?? 0,
+      _start: startMs,
+      _end: Math.min(endMs, windowEnd),
+      _index: buckets.length,
+    })
+  }
+
   return buckets
 }
 

--- a/dashboard/src/pages/events-feed.tsx
+++ b/dashboard/src/pages/events-feed.tsx
@@ -1,14 +1,17 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import { useResizableFilterWidth } from "@/hooks/use-resizable-filter-width"
 import { useSearchParams } from "react-router"
-import { listEvents, type EventResponse } from "@/lib/api"
+import { listEvents, getEventHistogram, type EventResponse } from "@/lib/api"
 import { useDashboardSSE } from "@/hooks/use-dashboard-sse"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useViewOptions } from "@/lib/hooks/use-view-options"
 import { EventFilterPanel } from "./events/event-filter-panel"
 import { EventList } from "./events/event-list"
 import { EventsToolbar } from "./events/events-toolbar"
-import { type TimeWindow, DEFAULT_TIME_WINDOW, resolveWindow } from "@/lib/histogram"
+import {
+  type TimeWindow, type HistogramBucket,
+  DEFAULT_TIME_WINDOW, resolveWindow, bestBucketConfig, buildHistogramFromServer,
+} from "@/lib/histogram"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -74,6 +77,7 @@ export function EventsFeed() {
   const [newEventCount, setNewEventCount] = useState(0)
   const [loadingMore, setLoadingMore] = useState(false)
   const [hasMore, setHasMore] = useState(false)
+  const [histogramData, setHistogramData] = useState<HistogramBucket[]>([])
 
   // Refs for cursor-based pagination (avoid stale closures in async callbacks)
   const eventsRef = useRef<EventResponse[]>([])
@@ -198,10 +202,30 @@ export function EventsFeed() {
     }
   }, [serverFilters, sinceIso])
 
+  // Fetch histogram (server-side aggregation — shows full picture regardless of pagination)
+  const fetchHistogram = useCallback(async () => {
+    try {
+      const { start, end } = resolveWindow(timeWindow)
+      const windowMs = end - start
+      const { bucketMs } = bestBucketConfig(windowMs)
+      const data = await getEventHistogram({
+        since: new Date(start).toISOString(),
+        until: new Date(end).toISOString(),
+        bucket_seconds: Math.round(bucketMs / 1000),
+        ...serverFilters,
+      })
+      setHistogramData(buildHistogramFromServer(data, timeWindow))
+    } catch {
+      // Histogram failure shouldn't block the page
+      setHistogramData([])
+    }
+  }, [timeWindow, serverFilters])
+
   // Fetch when filters or timeframe change
   useEffect(() => {
     void fetchEvents()
-  }, [fetchEvents])
+    void fetchHistogram()
+  }, [fetchEvents, fetchHistogram])
 
   // SSE for real-time events — accumulate count when live
   useDashboardSSE(
@@ -219,7 +243,8 @@ export function EventsFeed() {
   const handleShowNewEvents = useCallback(() => {
     setNewEventCount(0)
     void fetchEvents()
-  }, [fetchEvents])
+    void fetchHistogram()
+  }, [fetchEvents, fetchHistogram])
 
   // Toggle live/paused
   const handleToggleLive = useCallback(() => {
@@ -394,7 +419,7 @@ export function EventsFeed() {
     density: options.density,
     wrapData: options.wrapData,
     showHistogram: options.panels.histogram,
-    timeWindow,
+    histogramData,
     expandedEventId,
     onToggleExpand: handleToggleExpand,
     highlightedEventId,

--- a/dashboard/src/pages/events/event-list.tsx
+++ b/dashboard/src/pages/events/event-list.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/payload-helpers"
 import { verdictColor, VerdictIcon } from "@/lib/verdict-helpers"
 import { formatTime, truncate } from "@/lib/format"
-import { buildHistogram, type TimeWindow } from "@/lib/histogram"
+import { type HistogramBucket, type TimeWindow } from "@/lib/histogram"
 import { EnvBadge } from "@/lib/env-colors"
 import { EventHistogram } from "./event-histogram"
 import { EventRowDetail } from "./event-row-detail"
@@ -62,7 +62,7 @@ interface EventListProps {
   density: Density
   wrapData: boolean
   showHistogram: boolean
-  timeWindow: TimeWindow
+  histogramData: HistogramBucket[]
   expandedEventId: string | null
   onToggleExpand: (id: string) => void
   highlightedEventId: string | null
@@ -79,7 +79,7 @@ export function EventList({
   density,
   wrapData,
   showHistogram,
-  timeWindow,
+  histogramData,
   expandedEventId,
   onToggleExpand,
   highlightedEventId,
@@ -89,7 +89,6 @@ export function EventList({
   loadingMore,
   hasMore,
 }: EventListProps) {
-  const histogramData = useMemo(() => buildHistogram(events, timeWindow), [events, timeWindow])
   const rowRefs = useRef<Map<string, HTMLElement>>(new Map())
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)

--- a/src/edictum_server/routes/events.py
+++ b/src/edictum_server/routes/events.py
@@ -100,7 +100,7 @@ async def get_event_histogram(
 ) -> list[HistogramBucketResponse]:
     """Return event counts bucketed by time for histogram visualization."""
     env_filter = auth.env if auth.auth_type == "api_key" else None
-    rows = await query_event_histogram(
+    return await query_event_histogram(
         db,
         auth.tenant_id,
         since=since,
@@ -111,7 +111,6 @@ async def get_event_histogram(
         verdict=verdict,
         env=env_filter,
     )
-    return [HistogramBucketResponse(**row) for row in rows]
 
 
 @router.get(

--- a/src/edictum_server/routes/events.py
+++ b/src/edictum_server/routes/events.py
@@ -20,8 +20,13 @@ from edictum_server.schemas.events import (
     EventBatchRequest,
     EventIngestResponse,
     EventResponse,
+    HistogramBucketResponse,
 )
-from edictum_server.services.event_service import ingest_events, query_events
+from edictum_server.services.event_service import (
+    ingest_events,
+    query_event_histogram,
+    query_events,
+)
 from edictum_server.services.manifest_service import store_agent_manifest
 
 router = APIRouter(prefix="/api/v1/events", tags=["events"])
@@ -76,6 +81,37 @@ async def post_events(
         )
 
     return EventIngestResponse(accepted=accepted, duplicates=duplicates)
+
+
+@router.get(
+    "/histogram",
+    response_model=list[HistogramBucketResponse],
+    summary="Get event histogram for a time window",
+)
+async def get_event_histogram(
+    since: datetime,
+    until: datetime,
+    bucket_seconds: int = Query(default=7200, ge=60, le=86400),
+    agent_id: str | None = None,
+    tool_name: str | None = None,
+    verdict: str | None = None,
+    auth: AuthContext = Depends(get_current_tenant),
+    db: AsyncSession = Depends(get_db),
+) -> list[HistogramBucketResponse]:
+    """Return event counts bucketed by time for histogram visualization."""
+    env_filter = auth.env if auth.auth_type == "api_key" else None
+    rows = await query_event_histogram(
+        db,
+        auth.tenant_id,
+        since=since,
+        until=until,
+        bucket_seconds=bucket_seconds,
+        agent_id=agent_id,
+        tool_name=tool_name,
+        verdict=verdict,
+        env=env_filter,
+    )
+    return [HistogramBucketResponse(**row) for row in rows]
 
 
 @router.get(

--- a/src/edictum_server/schemas/events.py
+++ b/src/edictum_server/schemas/events.py
@@ -71,3 +71,13 @@ class EventIngestResponse(BaseModel):
 
     accepted: int = Field(..., description="Number of newly stored events")
     duplicates: int = Field(..., description="Number of events skipped (already ingested)")
+
+
+class HistogramBucketResponse(BaseModel):
+    """A single time bucket with pre-classified event counts."""
+
+    bucket_start: datetime
+    allowed: int = 0
+    denied: int = 0
+    pending: int = 0
+    observed: int = 0

--- a/src/edictum_server/services/event_service.py
+++ b/src/edictum_server/services/event_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import delete, insert, select
+from sqlalchemy import Integer, delete, func, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.db.models import Event
@@ -97,6 +97,91 @@ async def query_events(
     stmt = stmt.order_by(Event.timestamp.desc()).limit(limit)
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def query_event_histogram(
+    db: AsyncSession,
+    tenant_id: uuid.UUID,
+    *,
+    since: datetime,
+    until: datetime,
+    bucket_seconds: int,
+    agent_id: str | None = None,
+    tool_name: str | None = None,
+    verdict: str | None = None,
+    env: str | None = None,
+) -> list[dict[str, object]]:
+    """Aggregate event counts into epoch-aligned time buckets.
+
+    Returns pre-classified buckets with allowed/denied/pending/observed counts.
+    Observe-mode denials are categorized as 'observed'.
+    """
+    dialect_name = db.bind.dialect.name if db.bind else "postgresql"
+
+    if dialect_name == "postgresql":
+        epoch = func.extract("epoch", Event.timestamp)
+    else:
+        epoch = func.cast(func.strftime("%s", Event.timestamp), Integer)
+
+    bucket_col = (func.cast(epoch / bucket_seconds, Integer) * bucket_seconds).label(
+        "bucket_epoch"
+    )
+
+    stmt = (
+        select(
+            bucket_col,
+            Event.verdict,
+            Event.mode,
+            func.count().label("cnt"),
+        )
+        .where(Event.tenant_id == tenant_id)
+        .where(Event.timestamp >= since)
+        .where(Event.timestamp < until)
+    )
+
+    if agent_id is not None:
+        stmt = stmt.where(Event.agent_id == agent_id)
+    if tool_name is not None:
+        stmt = stmt.where(Event.tool_name == tool_name)
+    if verdict is not None:
+        stmt = stmt.where(Event.verdict == verdict)
+    if env is not None:
+        stmt = stmt.where(Event.env == env)
+
+    stmt = stmt.group_by(bucket_col, Event.verdict, Event.mode).order_by(bucket_col)
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    # Classify verdict/mode into categories and aggregate per bucket
+    buckets: dict[int, dict[str, int]] = {}
+    for row in rows:
+        epoch_val = int(row.bucket_epoch)
+        cnt = int(row.cnt)
+
+        if epoch_val not in buckets:
+            buckets[epoch_val] = {"allowed": 0, "denied": 0, "pending": 0, "observed": 0}
+
+        b = buckets[epoch_val]
+
+        # Observe-mode denials → observed category
+        if row.mode == "observe" and row.verdict in ("call_would_deny", "call_denied"):
+            b["observed"] += cnt
+        elif row.verdict in ("allowed", "call_allowed"):
+            b["allowed"] += cnt
+        elif row.verdict in ("denied", "call_denied", "would_deny", "call_would_deny"):
+            b["denied"] += cnt
+        elif row.verdict in ("pending", "pending_approval"):
+            b["pending"] += cnt
+        else:
+            b["allowed"] += cnt  # fallback for unknown verdicts
+
+    return [
+        {
+            "bucket_start": datetime.fromtimestamp(epoch_val, UTC),
+            **counts,
+        }
+        for epoch_val, counts in sorted(buckets.items())
+    ]
 
 
 async def purge_events(

--- a/src/edictum_server/services/event_service.py
+++ b/src/edictum_server/services/event_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import Integer, delete, func, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from edictum_server.db.models import Event
-from edictum_server.schemas.events import EventPayload
+from edictum_server.schemas.events import EventPayload, HistogramBucketResponse
 
 
 async def ingest_events(
@@ -110,7 +110,7 @@ async def query_event_histogram(
     tool_name: str | None = None,
     verdict: str | None = None,
     env: str | None = None,
-) -> list[dict[str, object]]:
+) -> list[HistogramBucketResponse]:
     """Aggregate event counts into epoch-aligned time buckets.
 
     Returns pre-classified buckets with allowed/denied/pending/observed counts.
@@ -118,6 +118,7 @@ async def query_event_histogram(
     """
     dialect_name = db.bind.dialect.name if db.bind else "postgresql"
 
+    epoch: object  # sqlalchemy column expression — varies by dialect
     if dialect_name == "postgresql":
         epoch = func.extract("epoch", Event.timestamp)
     else:
@@ -176,10 +177,13 @@ async def query_event_histogram(
             b["allowed"] += cnt  # fallback for unknown verdicts
 
     return [
-        {
-            "bucket_start": datetime.fromtimestamp(epoch_val, UTC),
-            **counts,
-        }
+        HistogramBucketResponse(
+            bucket_start=datetime.fromtimestamp(epoch_val, UTC),
+            allowed=counts["allowed"],
+            denied=counts["denied"],
+            pending=counts["pending"],
+            observed=counts["observed"],
+        )
         for epoch_val, counts in sorted(buckets.items())
     ]
 


### PR DESCRIPTION
## Summary

- Histogram was built client-side from loaded events only — with pagination (200 at a time), most time buckets showed empty
- Added `GET /api/v1/events/histogram` backend endpoint with SQL aggregation (epoch-aligned bucketing, works on Postgres + SQLite)
- Frontend fetches histogram separately from paginated events — always shows the complete distribution
- Works with any time window (15m to 30d+) — bucket size adapts automatically via `bestBucketConfig()`

## Changes

**Backend (3 files):**
- `schemas/events.py` — `HistogramBucketResponse` model
- `services/event_service.py` — `query_event_histogram()` with dialect-aware epoch bucketing + verdict classification
- `routes/events.py` — `GET /api/v1/events/histogram` endpoint (tenant-scoped, same filters as event list)

**Frontend (4 files):**
- `lib/api/events.ts` — `getEventHistogram()` API client
- `lib/histogram.ts` — `buildHistogramFromServer()` + exported `bestBucketConfig()`
- `pages/events-feed.tsx` — separate histogram fetch, passes data to EventList
- `pages/events/event-list.tsx` — receives `histogramData` prop instead of computing client-side

## Test plan

- [ ] Events page histogram shows full distribution for 24h and 7d windows
- [ ] Histogram updates when time window or filters change
- [ ] Histogram updates when "Show new events" is clicked
- [ ] Scrolling to load more events does NOT affect the histogram
- [ ] Empty time windows show empty histogram (no errors)
- [ ] Clicking a histogram bar still zooms to that time range